### PR TITLE
Implement install help toggle

### DIFF
--- a/ds10-poc-final.html
+++ b/ds10-poc-final.html
@@ -492,11 +492,15 @@
                     <div class="step-indicator">2</div>
                     <h3 style="margin-bottom: 1rem;">Install Files</h3>
                     <p style="margin-bottom: 1rem; opacity: 0.8;">Drop the files into your Valheim directory.</p>
-                    <span class="hover-hint" 
-                          onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'block' ? 'none' : 'block'">
-                        Where's my install folder
+                    <span class="hover-hint"
+                          onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'block' ? 'none' : 'block'"
+                          onmouseenter="this.nextElementSibling.style.display = 'block'"
+                          onfocus="this.nextElementSibling.style.display = 'block'"
+                          onmouseleave="this.nextElementSibling.style.display = 'none'"
+                          onblur="this.nextElementSibling.style.display = 'none'">
+                        Where do I find it?
                     </span>
-                    <div style="display: none; margin-top: 1rem; padding: 1rem; background: rgba(75, 145, 226, 0.1); border-radius: 8px; font-size: 0.875rem;">
+                    <div id="install-hint" style="display: none; margin-top: 1rem; padding: 1rem; background: rgba(75, 145, 226, 0.1); border-radius: 8px; font-size: 0.875rem;">
                         Right click Valheim in Steam → Manage → Browse local files
                     </div>
                 </div>

--- a/src/components/SetupInstructions.tsx
+++ b/src/components/SetupInstructions.tsx
@@ -4,6 +4,10 @@ import './SetupInstructions.css'
 function SetupInstructions() {
   const [showInstallHint, setShowInstallHint] = useState(false)
 
+  const showHint = () => setShowInstallHint(true)
+  const hideHint = () => setShowInstallHint(false)
+  const toggleHint = () => setShowInstallHint(!showInstallHint)
+
   return (
     <section className="section setup-section" id="setup-instructions">
       <div className="container">
@@ -36,15 +40,20 @@ function SetupInstructions() {
             <div className="step-indicator">2</div>
             <h3>Install Files</h3>
             <p>Drop the files into your Valheim directory.</p>
-            <button 
-              className="hover-hint" 
-              onClick={() => setShowInstallHint(!showInstallHint)}
+            <button
+              className="hover-hint"
+              onClick={toggleHint}
+              onMouseEnter={showHint}
+              onFocus={showHint}
+              onMouseLeave={hideHint}
+              onBlur={hideHint}
               aria-expanded={showInstallHint}
+              aria-controls="install-hint"
             >
-              Where's my install folder
+              Where do I find it?
             </button>
             {showInstallHint && (
-              <div className="hint-box">
+              <div className="hint-box" id="install-hint">
                 Right click Valheim in Steam → Manage → Browse local files
               </div>
             )}

--- a/tests/spec-compliance.spec.ts
+++ b/tests/spec-compliance.spec.ts
@@ -28,7 +28,7 @@ test.describe('DS-10 Site Spec Compliance', () => {
 
   test('Hero buttons have correct styling and behavior', async ({ page }) => {
     const serverDetailsBtn = page.locator('button:has-text("Server Details")');
-    const quickStartBtn = page.locator('button:has-text("Quick Start")');
+    const quickStartBtn = page.locator('button:has-text("Install")');
     
     await expect(serverDetailsBtn).toBeVisible();
     await expect(quickStartBtn).toBeVisible();
@@ -43,7 +43,7 @@ test.describe('DS-10 Site Spec Compliance', () => {
     await page.evaluate(() => window.scrollTo(0, 0));
     await page.waitForTimeout(500);
     
-    // Test Quick Start button scroll
+    // Test Install button scroll
     await quickStartBtn.click();
     await page.waitForTimeout(1000);
     const setupSection = page.locator('#setup-instructions');
@@ -71,7 +71,7 @@ test.describe('DS-10 Site Spec Compliance', () => {
   });
 
   test('install folder hint reveals on click', async ({ page }) => {
-    const hintButton = page.locator('button:has-text("Where\'s my install folder")');
+    const hintButton = page.locator('button:has-text("Where do I find it?")');
     const hintBox = page.locator('.hint-box');
     
     // Initially hidden
@@ -147,7 +147,7 @@ test.describe('DS-10 Site Spec Compliance', () => {
   test('all interactive elements have proper ARIA labels', async ({ page }) => {
     // Hero buttons
     const serverDetailsBtn = page.locator('button:has-text("Server Details")');
-    const quickStartBtn = page.locator('button:has-text("Quick Start")');
+    const quickStartBtn = page.locator('button:has-text("Install")');
     await expect(serverDetailsBtn).toHaveAttribute('aria-label', 'Scroll to server connection details');
     await expect(quickStartBtn).toHaveAttribute('aria-label', 'Scroll to setup instructions');
     
@@ -170,7 +170,7 @@ test.describe('DS-10 Site Spec Compliance', () => {
     
     // Tab to next button
     await page.keyboard.press('Tab');
-    const quickStartBtn = page.locator('button:has-text("Quick Start")');
+    const quickStartBtn = page.locator('button:has-text("Install")');
     await expect(quickStartBtn).toBeFocused();
   });
 


### PR DESCRIPTION
## Summary
- expand install instructions: hint text toggles on hover/click/focus
- update static HTML POC to match new behaviour
- fix Playwright tests for updated button labels

## Testing
- `npm test` *(fails: `npm` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f2d57ba0c8321a9db44c444cf779b