### PR TITLE
Add interactive directory tree component

### DIFF
--- a/src/components/GameDirectoryTree.tsx
+++ b/src/components/GameDirectoryTree.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import styles from '../styles/modules/GameDirectoryTree.module.css'
+
+const lines = [
+  { text: 'Valheim/', className: styles.root },
+  { text: '├── valheim.exe                 ✅', className: styles.existing },
+  { text: '├── valheim_Data/              ✅', className: styles.existing },
+  { text: '├── UnityPlayer.dll            ✅', className: styles.existing },
+  { text: '├── UnityCrashHandler64.exe    ✅', className: styles.existing },
+  { text: '├── steam_appid.txt            ✅', className: styles.existing },
+  { text: '├── 📦 BepInEx/', className: styles.modpackFolder, tooltip: true },
+  { text: '├── 📦 doorstop_libs/', className: styles.modpackFolder, tooltip: true },
+  { text: '├── 📄 changelog.txt', className: styles.modpackFile, tooltip: true },
+  { text: '├── 📄 doorstop_config.ini', className: styles.modpackFile, tooltip: true },
+  { text: '├── 📄 start_game_bepinex.sh', className: styles.modpackFile, tooltip: true },
+  { text: '├── 📄 start_server_bepinex.sh', className: styles.modpackFile, tooltip: true },
+  { text: '└── 📄 winhttp.dll', className: styles.modpackFile, tooltip: true }
+]
+
+function GameDirectoryTree() {
+  const [copied, setCopied] = useState(false)
+
+  const copyTree = () => {
+    const text = lines.map(l => l.text).join('\n')
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <button className={`${styles.copyButton} ${copied ? styles.copied : ''}`} onClick={copyTree} aria-label="Copy directory tree">
+        {copied ? 'Copied!' : 'Copy'}
+      </button>
+      <pre className={styles.tree}>
+        {lines.map((line, idx) => (
+          <code
+            key={idx}
+            className={`${styles.line} ${line.className}`}
+            data-tooltip={line.tooltip ? 'Included in the Deep Space 10 modpack' : undefined}
+          >
+            {line.text}
+          </code>
+        ))}
+      </pre>
+    </div>
+  )
+}
+
+export default GameDirectoryTree

--- a/src/components/SetupInstructions.tsx
+++ b/src/components/SetupInstructions.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import './SetupInstructions.css'
+import GameDirectoryTree from './GameDirectoryTree'
 
 function SetupInstructions() {
   const [showInstallHint, setShowInstallHint] = useState(false)
@@ -62,6 +63,7 @@ function SetupInstructions() {
             </div>
           </div>
         </div>
+        <GameDirectoryTree />
       </div>
     </section>
   )

--- a/src/styles/modules/GameDirectoryTree.module.css
+++ b/src/styles/modules/GameDirectoryTree.module.css
@@ -1,0 +1,87 @@
+.wrapper {
+  position: relative;
+  display: inline-block;
+  margin-top: 1rem;
+}
+
+.copyButton {
+  position: absolute;
+  right: 0.5rem;
+  top: -2rem;
+  background: var(--runestone-blue);
+  color: white;
+  border: none;
+  padding: 0.25rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.copyButton:hover {
+  background: var(--solar-flare-amber);
+}
+
+.copied {
+  background: var(--solar-flare-amber);
+}
+
+.tree {
+  font-family: 'JetBrains Mono', monospace;
+  background: rgba(31, 31, 35, 0.6);
+  padding: 1rem;
+  border-radius: 8px;
+  border: 1px solid rgba(199, 204, 214, 0.1);
+  color: var(--moonstone-steel);
+  overflow-x: auto;
+}
+
+.line {
+  display: block;
+  white-space: pre;
+  transition: transform 0.2s;
+  position: relative;
+}
+
+.existing {
+  color: #aaaaaa;
+}
+
+.modpackFolder {
+  font-weight: 700;
+  color: var(--runestone-blue);
+}
+
+.modpackFile {
+  color: var(--solar-flare-amber);
+}
+
+.line[data-tooltip]:hover {
+  transform: scale(1.02);
+}
+
+.line[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translate(0, -50%) scale(0.8);
+  background: rgba(0, 0, 0, 0.75);
+  color: white;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  opacity: 0;
+  white-space: nowrap;
+  transition: opacity 0.2s, transform 0.2s;
+  margin-left: 0.5rem;
+  pointer-events: none;
+}
+
+.line[data-tooltip]:hover::after {
+  opacity: 1;
+  transform: translate(0, -50%) scale(1);
+}
+
+.root {
+  font-weight: 700;
+}

--- a/src/styles/modules/GameDirectoryTree.module.css.d.ts
+++ b/src/styles/modules/GameDirectoryTree.module.css.d.ts
@@ -1,0 +1,12 @@
+declare const styles: {
+  wrapper: string;
+  copyButton: string;
+  copied: string;
+  tree: string;
+  line: string;
+  existing: string;
+  modpackFolder: string;
+  modpackFile: string;
+  root: string;
+};
+export default styles;


### PR DESCRIPTION
## Summary
- embed new `GameDirectoryTree` component for modpack files
- style directory tree with CSS module
- type declarations for styles
- show directory tree in setup instructions

## Testing
- `npm run build` *(fails: React types missing)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f33a518d083218f5c34ea73b48053