### PR TITLE
Add directory tree component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import Hero from './components/Hero'
 import SetupInstructions from './components/SetupInstructions'
 import ServerDetails from './components/ServerDetails'
 import Background from './components/Background'
+import DirectoryTree from './components/DirectoryTree'
 
 function App() {
   return (
@@ -10,6 +11,7 @@ function App() {
       <Hero />
       <main>
         <SetupInstructions />
+        <DirectoryTree />
         <ServerDetails />
       </main>
     </>

--- a/src/components/DirectoryTree.css
+++ b/src/components/DirectoryTree.css
@@ -1,0 +1,72 @@
+.file-tree-container {
+  position: relative;
+  font-family: "JetBrains Mono", monospace;
+  background: var(--meteor-gray);
+  padding: 1rem;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+.file-tree {
+  margin: 0;
+  white-space: pre;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: var(--runestone-blue);
+  color: white;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.file-tree span {
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.modpack:hover span {
+  transform: scale(1.05);
+  opacity: 0.9;
+}
+
+.modpack {
+  font-weight: bold;
+  color: var(--runestone-blue);
+  position: relative;
+}
+
+.modpack-file {
+  color: var(--solar-flare-amber);
+}
+
+.tooltip {
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translate(0, -50%);
+  background: var(--meteor-gray);
+  color: var(--moonstone-steel);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.modpack:hover .tooltip {
+  opacity: 1;
+}
+
+.existing {
+  color: var(--moonstone-steel);
+}

--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -1,0 +1,38 @@
+import { useRef } from 'react'
+import { copyToClipboard } from '../utils/clipboard'
+import './DirectoryTree.css'
+
+function DirectoryTree() {
+  const treeRef = useRef<HTMLPreElement>(null)
+
+  const handleCopy = async () => {
+    if (treeRef.current) {
+      await copyToClipboard(treeRef.current.innerText)
+    }
+  }
+
+  return (
+    <div className="file-tree-container">
+      <button className="copy-btn" onClick={handleCopy} aria-label="Copy folder structure">Copy</button>
+      <pre ref={treeRef} className="file-tree" aria-label="Valheim directory layout">
+        <code>
+          <span className="existing">Valheim/</span>{"\n"}
+          <span className="existing">├── valheim.exe</span>{"\n"}
+          <span className="existing">├── valheim_Data/</span>{"\n"}
+          <span className="existing">├── UnityPlayer.dll</span>{"\n"}
+          <span className="existing">├── UnityCrashHandler64.exe</span>{"\n"}
+          <span className="existing">├── steam_appid.txt</span>{"\n"}
+          <span className="modpack">├── 📦 BepInEx/<span className="tooltip">Included in the Deep Space 10 modpack</span></span>{"\n"}
+          <span className="modpack">├── 📦 doorstop_libs/<span className="tooltip">Included in the Deep Space 10 modpack</span></span>{"\n"}
+          <span className="modpack-file">├── 📄 changelog.txt<span className="tooltip">Included in the Deep Space 10 modpack</span></span>{"\n"}
+          <span className="modpack-file">├── 📄 doorstop_config.ini<span className="tooltip">Included in the Deep Space 10 modpack</span></span>{"\n"}
+          <span className="modpack-file">├── 📄 start_game_bepinex.sh<span className="tooltip">Included in the Deep Space 10 modpack</span></span>{"\n"}
+          <span className="modpack-file">├── 📄 start_server_bepinex.sh<span className="tooltip">Included in the Deep Space 10 modpack</span></span>{"\n"}
+          <span className="modpack-file">└── 📄 winhttp.dll<span className="tooltip">Included in the Deep Space 10 modpack</span></span>
+        </code>
+      </pre>
+    </div>
+  )
+}
+
+export default DirectoryTree


### PR DESCRIPTION
## Summary
- add interactive directory tree component
- style directory tree with color-coding, hover and copy button
- render the tree in the app

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run build` *(fails: unable to find react/jsx-runtime)*

------
https://chatgpt.com/codex/tasks/task_e_687f33a518d083218f5c34ea73b48053